### PR TITLE
corrige bug con el rendereo de múltiples tablas en una sóla vista

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,9 +8,9 @@ module.exports = function(config) {
         // browsers: ['Chrome'],
 
         files: [
-            './node_modules/jquery/dist/jquery.js',
-            './specs/stubs/materialize.js',
-            './specs/stubs/vue-html5-editor.js',
+            // './node_modules/jquery/dist/jquery.js',
+            // './specs/stubs/materialize.js',
+            // './specs/stubs/vue-html5-editor.js',
             './node_modules/phantomjs-polyfill/bind-polyfill.js',
             { pattern: 'test-context.js'}
         ],
@@ -40,7 +40,7 @@ module.exports = function(config) {
         },
         webpack: {
             entry: {
-                index: './src/example.js'
+                index: './src/list-filters.js'
             },
             module: {
                 rules: [

--- a/specs/list-filters-spec.js
+++ b/specs/list-filters-spec.js
@@ -3,7 +3,9 @@ import Vue from 'vue'
 import {listFilters, isPath, isPathInObjArray, isStringArray} from '../src/list-filters'
 import {users, makeUsers} from './list-filters/users.js'
 
-fdescribe('list-filters.js', () => {
+const myTable = Vue.extend({template: '<div v-for="item in list" v-text="item"></div>', mixins: [listFilters], props: ['list']})
+
+describe('list-filters.js', () => {
 	let vm = {}
 
 	beforeEach(() => {
@@ -11,6 +13,8 @@ fdescribe('list-filters.js', () => {
 			replace:false,//no es necesario fuera del test, es sólo para cuando usamos el método mount sobre el body
 			template: `
 			<div>
+				<my-table :list="[1,2,3]"></my-table>
+				<my-table :list="[4,5,6]"></my-table>
 			</div>`,
 			mixins: [listFilters],
 			// ready() {console.log(this.$children);},
@@ -20,12 +24,11 @@ fdescribe('list-filters.js', () => {
 					event: {meetings: []}
 				},
 			},
-			components: {},
+			components: { myTable },
 			methods: {
 			}
 		}).$mount('body')
 		// vm.list = users
-
 	}) 
 	
 	it('pude encontrar uno o más usuarios por nombre', function(done) {
@@ -210,13 +213,15 @@ fdescribe('list-filters.js', () => {
 				let newbuddy = vm.list[98]
 				newbuddy.full_name = 'Buddy100'
 				vm.list.push(newbuddy)
-
+				vm.search = ''
 				Vue.nextTick(()=>{
+
 					expect(vm.memorized_filters['filter_by_state$search_statey8']).toEqual(undefined)
+					vm.search = 'statey8'
 					setTimeout(()=>{
 						expect(vm.memorized_filters['filter_by_state$search_statey8'].length).toEqual(found.length + 1)
 						done()
-					}, 300)
+					}, 200)
 				})
 			}, 300)
 		});
@@ -266,6 +271,14 @@ fdescribe('list-filters.js', () => {
 				}, 300)
 			}, 300)
 		});
+
+		it('puede renderear multiples componentes con listas filtables correctamente', done => {
+			setTimeout(() => {
+				expect(vm.$children[0].filtered_list).toEqual([1,2,3])
+				expect(vm.$children[1].filtered_list).toEqual([4,5,6])
+				done()
+			}, 300)
+		})
 	});
 });
 

--- a/src/list-filters.js
+++ b/src/list-filters.js
@@ -57,9 +57,9 @@ export const listFilters = {
     },
 
     methods: {
-        filterList: debounce(function() {
+        filterList: function() {
             let filters = R.path([this.filter_by, 'filters'], this.filters)
-            //Optimización: memoización
+            //Optimización: memoización            
             let filtered_list = R.pathOr([], ['memorized_filters', `filter_by_${this.filter_by}$search_${this.search}`], this)
 
             if (filtered_list.length !== 0) {
@@ -88,11 +88,12 @@ export const listFilters = {
             this.previous_search = this.search
             // console.log("this.previous_search", this.previous_search);
             this.previous_filter = this.filter_by
-        }, 100)
+        }
     },
 
     watch: {
         list() {//al actualizarse la lista original tenemos que resetar todo el estado que nos permite optimizar las búsquedas
+            
             this.memorized_filters = {}
             this.previous_search = ''
             this.filterList()
@@ -106,8 +107,8 @@ export const listFilters = {
             this.filterList()
         },
 
-        search() {
+        search: debounce(function () {
             this.filterList()
-        }
+        }, 100)
     }
 }


### PR DESCRIPTION
corrige bug con el rendereo de múltiples tablas en una sola vista donde el debounce de filterList prevenía que se renderearan todas las listas. El debounce se mueve al watch de  search